### PR TITLE
fix-generated-pdf-data-width

### DIFF
--- a/webmupdf/converter.py
+++ b/webmupdf/converter.py
@@ -94,7 +94,7 @@ def get_page(file_bin, page_num, file_type, width_output_file):
     # Transform raw data extracted from the pdf into structured dict generated_pdf_data
     if is_generated_pdf:
         words = page.getText('WORDS', 0)  # this 0 argument excludes whitespaces and extends ligatures
-        generated_pdf_data['width'] = smallest_side
+        generated_pdf_data['width'] = page_width
         generated_pdf_data['words'] = [
             {
                 u"position": {


### PR DESCRIPTION
fix(converter): make generated_pdf_data width the actual width instead of the smallest side